### PR TITLE
Add Git repository for Solarized theme

### DIFF
--- a/plugin/vim-addon-manager-known-repositories.vim
+++ b/plugin/vim-addon-manager-known-repositories.vim
@@ -3850,6 +3850,9 @@ let s:scm_plugin_sources['xmledit'] = {'type': 'git', 'url': 'git://github.com/s
 " Thiago Alves
 let s:scm_plugin_sources['AutoClose'] = {'type': 'git', 'url': 'git://github.com/Townk/vim-autoclose.git', 'author': 'Thiago Alves'}
 
+" Ethan Schoonover
+let s:scm_plugin_sources['Solarized'] = {'type': 'git', 'url': 'git://github.com/altercation/vim-colors-solarized.git', 'author': 'Ethan Schoonover'}
+
 "}}}
 "Additional sources information {{{
 let s:plugin_sources['vimpager-perlmod'] = {'type': 'git', 'url': 'git://github.com/trapd00r/vimpager-perlmod.git'}


### PR DESCRIPTION
The script on vim.org is not up to date, so it would be nice if VAM would use the Git repository instead. Here's a fix for that :)
