### PR TITLE
include github repos vim-pep8 and pyflakes-vim repos

### DIFF
--- a/plugin/vim-addon-manager-known-repositories.vim
+++ b/plugin/vim-addon-manager-known-repositories.vim
@@ -4309,8 +4309,8 @@ let s:scm_plugin_sources['UT'] = {"type": "svn", "url": "http://lh-vim.googlecod
 let s:scm_plugin_sources['quicksilver'] = { 'type': 'git', 'url': 'git://github.com/Bogdanp/quicksilver.vim.git' }
 
 " thet
-let s:scm_plugin_sources['vim-pep8'] = { 'type' : 'git', 'url' : 'git://github.com/nvie/vim-pep8.git' }
-let s:scm_plugin_sources['pyflakes-vim'] = { 'type' : 'git', 'url' : 'git://github.com/kevinw/pyflakes-vim.git' }
+let s:scm_plugin_sources['pep83160'] = { 'type' : 'git', 'url' : 'git://github.com/nvie/vim-pep8.git' }
+let s:scm_plugin_sources['pyflakes2441'] = { 'type' : 'git', 'url' : 'git://github.com/kevinw/pyflakes-vim.git' }
 
 " add / correct some types:
 let s:plugin_sources['php1571']['strip-components'] = 0


### PR DESCRIPTION
hi,
i've included two more repositories:
git://github.com/nvie/vim-pep8.git
git://github.com/kevinw/pyflakes-vim.git

they have some more changes than the plugins released on vim.org

it would be nice to have them in the official vim-addon-manager-known-repositories

thanks,
johannes raggam
