### PR TITLE
Add mustache.vim repository

### DIFF
--- a/plugin/vim-addon-manager-known-repositories.vim
+++ b/plugin/vim-addon-manager-known-repositories.vim
@@ -13,6 +13,7 @@ unlet s:c.vim_org_sources
 " SCM plugin sources {{{
 " this source seems to be more up to date then the www.vim.org version:
 let s:scm_plugin_sources = {}
+let s:scm_plugin_sources['mustache'] = { 'type' : 'git', 'url' : 'https://github.com/juvenn/mustache.vim.git' }
 let s:scm_plugin_sources['Command-T'] = { 'type' : 'git', 'url' : 'git://git.wincent.com/command-t.git' }
 let s:scm_plugin_sources['Conque_Shell'] = { 'type': 'svn', 'url': 'http://conque.googlecode.com/svn/trunk/' }
 let s:scm_plugin_sources['pyinteractive'] = { 'type' : 'hg', 'url' : 'https://vim-pyinteractive-plugin.googlecode.com/hg/' }


### PR DESCRIPTION
mustache.vim is a simple plugin for working with mustache templates. It has
both syntax hilighting and indenting, which just borrows from html indent
plugin.

https://github.com/juvenn/mustache.vim
