### PR TITLE
Add pbrisbin's Haskell HTML template syntax plugin.

### DIFF
--- a/db/scmsources.vim
+++ b/db/scmsources.vim
@@ -1848,6 +1848,7 @@ let scm['unicode-haskell'] = {'type': 'git', 'url': 'git://github.com/frerich/un
 let scm['vim-makegreen'] = {'type': 'git', 'url': 'git://github.com/reinh/vim-makegreen'}
 let scm['vim-rooter'] = {'type': 'git', 'url': 'git://github.com/airblade/vim-rooter'}
 let scm['vim-scala@behaghel'] = {'type': 'git', 'url': 'git://github.com/behaghel/vim-scala'}
+let scm['html-template-syntax'] = {'type': 'git', 'url': 'git://github.com/pbrisbin/html-template-syntax.git'}
 
 " Single files under SCM control without proper directory structure
 let scm['pgnvim'] = vamkr#AddCopyHook({'type': 'git', 'url': 'git://github.com/Raimondi/pgnvim'}, {'pgn.vim': 'syntax'})


### PR DESCRIPTION
This plugin consists of a set of syntax files for highlighting the various HTML
templating languages in Haskell, for example Hamlet, Cassius, Lucius, and
Julius.
