### PR TITLE
Add syntax highlighting for the Opa language.

### DIFF
--- a/db/scmsources.vim
+++ b/db/scmsources.vim
@@ -1848,6 +1848,7 @@ let scm['unicode-haskell'] = {'type': 'git', 'url': 'git://github.com/frerich/un
 let scm['vim-makegreen'] = {'type': 'git', 'url': 'git://github.com/reinh/vim-makegreen'}
 let scm['vim-rooter'] = {'type': 'git', 'url': 'git://github.com/airblade/vim-rooter'}
 let scm['vim-scala@behaghel'] = {'type': 'git', 'url': 'git://github.com/behaghel/vim-scala'}
+let scm['opalang'] = {'type': 'git', 'url': 'git://github.com/MLstate/opalang.git', 'addon-info': {'runtimepath': 'tools/editors/vim'}}
 
 " Single files under SCM control without proper directory structure
 let scm['pgnvim'] = vamkr#AddCopyHook({'type': 'git', 'url': 'git://github.com/Raimondi/pgnvim'}, {'pgn.vim': 'syntax'})


### PR DESCRIPTION
This plugin is directly based from the official Git repository of Opa.
