### PR TITLE
Updated vim-scala link to new repository

### DIFF
--- a/db/patchinfo.vim
+++ b/db/patchinfo.vim
@@ -95,8 +95,6 @@ let add_by_snr.159 ={'deprecated': "No more maintained, use â€œminibufexplorerâ€
 
 let add_by_snr.3901={'deprecated': "Accident (?) duplicate of vimscript #3900"}
 
-let add_by_snr.3524={'deprecated': "Script page and the only download suggest using git, but referenced repository is absent"}
-
 let add_by_snr.3881={'deprecated': "Superseeded by powerline (https://github.com/Lokaltog/powerline)"}
 
 let add_by_snr.3160={'deprecated': "According to github its superseded by vim-flake8 (vimscript #3927). You probably want to prefer syntastic anyway"}

--- a/db/scmsources.vim
+++ b/db/scmsources.vim
@@ -1959,10 +1959,8 @@ let scmnr.4438 = {'type': 'git', 'url': 'git://github.com/rdolgushin/rythm.vim'}
 "-----------------------------------------------------------------------------------------------------------------------
 
 " Derek Wyatt
-" Script page and the only download suggest using git, but referenced repository
-" is absent. Adding it here so that VAM users will get error from git if they
-" ignore deprecation instead of “Don’t know how to unpack” error.
-let scmnr.3524 = {'type': 'git', 'url': 'git://github.com/ewiplayer/vim-scala'}
+" Using the author's new github page. Link in vim.org is absent.
+let scmnr.3524 = {'type': 'git', 'url': 'git://github.com/derekwyatt/vim-scala.git'}
 
 " hickop
 " The following plugin does not have a separate repository:


### PR DESCRIPTION
Author has changed it's github account. This links to the new repo location.

Going to contact the author to update link in vim.org also.

Removed deprecation warning
