### PR TITLE
Add python-imports from Marius Gedminas

### DIFF
--- a/db/scmsources.vim
+++ b/db/scmsources.vim
@@ -2213,7 +2213,7 @@ let scm['SkyBison'] = {'type': 'git', 'url': 'git://github.com/paradigm/SkyBison
 let scm['jedi-vim'] = {'type': 'git', 'url': 'git://github.com/davidhalter/jedi-vim'}
 
 " Marius Gedminas
-let scm['python-imports2'] = {'type': 'git', 'url': 'git://github.com/mgedmin/python-imports.vim'}
+let scm['python-imports@mgedmin'] = {'type': 'git', 'url': 'git://github.com/mgedmin/python-imports.vim'}
 
 "-----------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
There is already an add-on called "python-imports", I'm not sure what the policy is in such cases.  Due to a lack of imagination, I named this one "python-imports2".
