### PR TITLE
account renamed to vivien

### DIFF
--- a/db/scmsources.vim
+++ b/db/scmsources.vim
@@ -1910,7 +1910,7 @@ let scmnr.4361 = {'type': 'git', 'url': 'git://github.com/can3p/incbool.vim'}
 let scmnr.4363 = {'type': 'git', 'url': 'git://github.com/Absolight/vim-bind'}
 
 " Vivien Didelot
-let scmnr.4369 = {'type': 'git', 'url': 'git://github.com/v0n/vim-addon-linux-coding-style'}
+let scmnr.4369 = {'type': 'git', 'url': 'git://github.com/vivien/vim-addon-linux-coding-style'}
 
 " Alexander Gorkunov
 let scmnr.4378 = {'type': 'git', 'url': 'git://github.com/gorkunov/smartpairs.vim'}


### PR DESCRIPTION
A few months ago, I renamed my account from "v0n" to "vivien".
This patch updates the git urls for my plugins.
